### PR TITLE
Add quick starter guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ build-docker: ## Builds a docker image from the dist directory
 	cp -R ./nginx/ ./dist/nginx
 	cd dist && docker build . -t $(DOCKERREPO)/apiscout:latest
 
-build-all: ## Performs clean-all and executes all build targets
-	clean-all build-site build-server build-docker
+## Performs clean-all and executes all build targets
+build-all: clean-all build-site build-server build-docker
 
 #--- Run targets ---
 run-server: ## Builds the  in the server directory and runs it with default settings
@@ -81,8 +81,8 @@ minikube-start: ## Start Minikube with default configuration
 	sudo -E minikube start --vm-driver=none
 minikube-stop: ## Stop Minikube
 	minikube stop
-minikube-delete: ## Delete the Minikube installation
-	minikube-stop
+## Delete the Minikube installation
+minikube-delete: minikube-stop
 	minikube delete
 minikube-show: ## Show the API Scout UI that is deployed to Minikube
 	open `minikube service apiscout-svc --url`

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,7 @@ build-docker: ## Builds a docker image from the dist directory
 	cp -R ./nginx/ ./dist/nginx
 	cd dist && docker build . -t $(DOCKERREPO)/apiscout:latest
 
-## Performs clean-all and executes all build targets
-build-all: clean-all build-site build-server build-docker
+build-all: clean-all build-site build-server build-docker ## Performs clean-all and executes all build targets
 
 #--- Run targets ---
 run-server: ## Builds the  in the server directory and runs it with default settings
@@ -81,8 +80,7 @@ minikube-start: ## Start Minikube with default configuration
 	sudo -E minikube start --vm-driver=none
 minikube-stop: ## Stop Minikube
 	minikube stop
-## Delete the Minikube installation
-minikube-delete: minikube-stop
+minikube-delete: minikube-stop ## Delete the Minikube installation
 	minikube delete
 minikube-show: ## Show the API Scout UI that is deployed to Minikube
 	open `minikube service apiscout-svc --url`

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This section provides minimal steps to get apiscout running inside a kuebernetes
 2. Build and deploy apiscout
 * `make deps`
 * `make build-all`
-* update `apiscout.yml` with kubernetes host ip and docker image name in `EXTERNALIP` value and `image` fields.
+* Update `apiscout.yml`<br>`EXTERNALIP` value with kubernetes host ip<br>`image` with docker image name built in the previous step `make build-all`
 * `make run-kube`
 3. Build and deploy sample micro service
 * Navigate to samples/invoiceservice-go folder - `cd samples/invoiceservice-go`
@@ -89,8 +89,7 @@ This section provides minimal steps to get apiscout running inside a kuebernetes
 * `make build-docker`
 * `make run-kube`
 4. Testing
-* Open kubernetes service url in browser to see swagger spec
-
+* Run `make minikube-show` or open kubernetes service url in browser to see swagger spec.
 
 ## License
 See the [LICENSE](./LICENSE) file

--- a/README.md
+++ b/README.md
@@ -65,32 +65,80 @@ apiscout has a few environment variables that the docker container (and thus the
 
 ## Getting started
 
-This section provides minimal steps to get apiscout running inside a kubernetes cluster on local machine / VM of your choice.
+This section provides minimal steps to get `apiscout` running inside a kubernetes cluster on local machine / VM of your choice.
 
 ### Prerequisites
 
 * Docker 
-* Kubernetes environment
+* Kubernetes environment (for example [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/))
 
 ### Steps to follow
 
-1. Setup up kubernetes environment from [here](https://kubernetes.io/docs/tasks/tools/install-minikube/)
-* `make minikube-install`. You can skip this if minikube already installed.
-* `make minikube-start`
+1. Start minikube
+```bash
+$ make minikube-start
+```
+
 2. Build and deploy apiscout
-* `make deps`
-* `make build-all`
-* Update `apiscout.yml`<br>`EXTERNALIP` value with kubernetes host ip<br>`image` with docker image name built in the previous step `make build-all`
-* `make run-kube`
+
+* Update `EXTERNALIP` value with minikube IP and `image` with docker image name in apiscout.yml
+```bash
+# Install dependencies
+$ make deps
+
+# Build apiscout docker image
+$ make build-all
+
+# Deploy apiscout to Kubernetes
+$ make run-kube
+```
+
 3. Build and deploy sample micro service
-* Navigate to samples/invoiceservice-go folder - `cd samples/invoiceservice-go`
-* `make deps`
-* `make build-app`
-* `make build-docker`
-* `make run-kube`
-4. Testing
-* Navigate back to apiscout directory - `cd ../..`
-* Run `make minikube-show` or open kubernetes service url in browser to see swagger spec.
+
+```bash
+# Navigate to samples/invoiceservice-go folder
+$ cd samples/invoiceservice-go
+
+# Install dependencies
+$ make deps
+
+# Build sample microservice application
+$ make build-app
+
+# Build dcoker image with the sample microservice application
+$ make build-docker
+
+# Deploy sample application to Kubernetes
+$ make run-kube
+
+```
+
+### Testing
+
+
+```bash
+# Navigate back to apiscout directory
+$ cd ../..
+
+# Open kubernetes service url in a web browser to see sample application api specification in swagger format
+$ make minikube-show
+
+```
+
+### Cleanup
+
+```bash
+# Delete sample application from Kubernetes
+$ cd samples/invoiceservice-go
+$ make clean-kube
+
+# Delete apiscout from Kubernetes
+$ cd ../..
+$ make clean-kube
+
+# Stop minikube
+$ make minikube-stop
+```
 
 ## License
 See the [LICENSE](./LICENSE) file

--- a/README.md
+++ b/README.md
@@ -63,18 +63,18 @@ apiscout has a few environment variables that the docker container (and thus the
 * **EXTERNALIP**: The external IP address of the Kubernetes cluster in case of LOCAL mode
 * **HUGODIR**: The base directory for Hugo
 
-## Getting started in few minutes
+## Getting started
 
-This section provides minimal steps to get apiscout running inside a kuebernetes cluster on local machine / VM of your chaoice.
+This section provides minimal steps to get apiscout running inside a kubernetes cluster on local machine / VM of your choice.
 
 ### Prerequisites
 
 * Docker 
-* Kubernetes environemnt
+* Kubernetes environment
 
 ### Steps to follow
 
-1. Setup up kuebernetes environment from [here](https://kubernetes.io/docs/tasks/tools/install-minikube/)
+1. Setup up kubernetes environment from [here](https://kubernetes.io/docs/tasks/tools/install-minikube/)
 * `make minikube-install`. You can skip this if minikube already installed.
 * `make minikube-start`
 2. Build and deploy apiscout
@@ -89,6 +89,7 @@ This section provides minimal steps to get apiscout running inside a kuebernetes
 * `make build-docker`
 * `make run-kube`
 4. Testing
+* Navigate back to apiscout directory - `cd ../..`
 * Run `make minikube-show` or open kubernetes service url in browser to see swagger spec.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -70,18 +70,18 @@ This section provides minimal steps to get apiscout running inside a kuebernetes
 ### Prerequisites
 
 * Docker 
-* Kubernetes environemnt (for example minikube)
+* Kubernetes environemnt
 
 ### Steps to follow
 
-1. Setup up kuebernetes environment
+1. Setup up kuebernetes environment from [here](https://kubernetes.io/docs/tasks/tools/install-minikube/)
 * `make minikube-install`. You can skip this if minikube already installed.
 * `make minikube-start`
 2. Build and deploy apiscout
 * `make deps`
 * `make build-all`
+* update `apiscout.yml` with kubernetes host ip and docker image name in `EXTERNALIP` value and `image` fields.
 * `make run-kube`
-* prepare `apiscout.yml`
 3. Build and deploy sample micro service
 * Navigate to samples/invoiceservice-go folder - `cd samples/invoiceservice-go`
 * `make deps`

--- a/README.md
+++ b/README.md
@@ -81,14 +81,16 @@ $ make minikube-start
 
 2. Build and deploy apiscout
 
-* Update `EXTERNALIP` value with minikube IP and `image` with docker image name in apiscout.yml
 ```bash
 # Install dependencies
 $ make deps
 
 # Build apiscout docker image
 $ make build-all
+```
+* Update `image` with apiscout docker image name built in the previous step and `EXTERNALIP` value with minikube IP in apiscout.yml 
 
+```bash
 # Deploy apiscout to Kubernetes
 $ make run-kube
 ```

--- a/README.md
+++ b/README.md
@@ -63,6 +63,35 @@ apiscout has a few environment variables that the docker container (and thus the
 * **EXTERNALIP**: The external IP address of the Kubernetes cluster in case of LOCAL mode
 * **HUGODIR**: The base directory for Hugo
 
+## Getting started in few minutes
+
+This section provides minimal steps to get apiscout running inside a kuebernetes cluster on local machine / VM of your chaoice.
+
+### Prerequisites
+
+* Docker 
+* Kubernetes environemnt (for example minikube)
+
+### Steps to follow
+
+1. Setup up kuebernetes environment
+* `make minikube-install`. You can skip this if minikube already installed.
+* `make minikube-start`
+2. Build and deploy apiscout
+* `make deps`
+* `make build-all`
+* `make run-kube`
+* prepare `apiscout.yml`
+3. Build and deploy sample micro service
+* Navigate to samples/invoiceservice-go folder - `cd samples/invoiceservice-go`
+* `make deps`
+* `make build-app`
+* `make build-docker`
+* `make run-kube`
+4. Testing
+* Open kubernetes service url in browser to see swagger spec
+
+
 ## License
 See the [LICENSE](./LICENSE) file
 

--- a/apiscout.yml
+++ b/apiscout.yml
@@ -38,7 +38,7 @@ spec:
         - name: HUGODIR
           value: "/tmp"
         - name: EXTERNALIP
-          value: "10.97.90.126"
+          value: "192.168.99.100"
         imagePullPolicy: Never
         ports:
         - containerPort: 80

--- a/apiscout.yml
+++ b/apiscout.yml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: apiscout
-        image: naresh/apiscout:latest
+        image:
         env:
         - name: MODE
           value: "KUBE"

--- a/apiscout.yml
+++ b/apiscout.yml
@@ -1,0 +1,60 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: default-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    run: apiscout
+  name: apiscout
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      run: apiscout
+  template:
+    metadata:
+      labels:
+        run: apiscout
+    spec:
+      containers:
+      - name: apiscout
+        image: naresh/apiscout:latest
+        env:
+        - name: MODE
+          value: "KUBE"
+        - name: HUGODIR
+          value: "/tmp"
+        - name: EXTERNALIP
+          value: "10.97.90.126"
+        imagePullPolicy: Never
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: apiscout-svc
+  name: apiscout-svc
+  namespace: default
+spec:
+  ports:
+  - port: 8181
+    protocol: TCP
+    targetPort: 80
+  selector:
+    run: apiscout
+  type: LoadBalancer


### PR DESCRIPTION
Added **Getting Started** section which provides step by step guide to deploy **apiscout** into Kubernetes cluster along with a sample microservice application.
This PR fixes #10